### PR TITLE
Optionally control on a specific MIDI channel

### DIFF
--- a/macro-b.lua
+++ b/macro-b.lua
@@ -29,7 +29,7 @@ local MacroB = require "mi-eng/lib/MacroB_engine"
 
 engine.name = "MacroB"
 
-local defualt_midicc = 32
+local default_midicc = 32
 local metarandom_cc = 47
 
 local message = ""
@@ -82,7 +82,7 @@ function init()
   local p = norns.pmap.data.contour
   --p = pmap.get("contour")
   if p == nil then
-    local i = defualt_midicc - 1
+    local i = default_midicc - 1
     for k,v in ipairs(param_assign) do
       controls[v].midi = i + 1 
       norns.pmap.new(v)

--- a/macro-b.lua
+++ b/macro-b.lua
@@ -76,6 +76,8 @@ function init()
   controls.ampSus = {ui = nil, midi = nil,}
   controls.ampRel = {ui = nil, midi = nil,}
 
+  params:add{type = "control", id = "midi_channel", name = "MIDI channel",
+    controlspec = controlspec.new(0, 16, "", 1, 0, ""), action = change_midi_channel}
 
   -- create midi pmap for 16n
   print ("check pmap")
@@ -104,7 +106,8 @@ function init()
 -- MIDI
 local mo = midi.connect() -- defaults to port 1 (which is set in SYSTEM > DEVICES)
 mo.event = function(data) 
-  d = midi.to_msg(data)
+d = midi.to_msg(data)
+if params:get('midi_channel') == 0 or d.ch == params:get('midi_channel') then
   if d.type == "note_on" then
     --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
     if metarandom then 
@@ -149,6 +152,7 @@ mo.event = function(data)
     end  
     redraw()    
   end 
+  end
 end
 
 
@@ -258,6 +262,11 @@ function meta_random()
     legend = "" .. braids_engines[meta]
     glyph = braids_glyphs[meta]
 
+end
+
+function change_midi_channel(d)
+  -- shush everything
+  engine.noteOff(0)
 end
 
 function redraw()

--- a/macro-b.lua
+++ b/macro-b.lua
@@ -103,58 +103,57 @@ function init()
     --tab.print (controls.bright)
   end
 
--- MIDI
-local mo = midi.connect() -- defaults to port 1 (which is set in SYSTEM > DEVICES)
-mo.event = function(data) 
-d = midi.to_msg(data)
-if params:get('midi_channel') == 0 or d.ch == params:get('midi_channel') then
-  if d.type == "note_on" then
-    --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
-    if metarandom then 
-      meta_random()
-    end
-    current_note = d.note
-    params:set("pitch", d.note)
-    controls.pitch.ui:set_value (d.note)
-    engine.noteOn(d.note, d.vel)
-    redraw()
-  elseif d.type == "note_off" then
-    engine.noteOff(0)
-  end 
-  if d.type == "cc" then
-    for k,v in pairs(controls) do
-        if d.cc == metarandom_cc and d.val > 64 then
-          metarandom = true
-        else
-          metarandom = false
-        end 
-        if controls[k].midi == d.cc then
-          --print ("cc: ".. d.cc .. ", val:" .. d.val)
-          if k == "pitch" then
-            controls[k].ui:set_value (d.val)
-            params:set(k, d.val)
-          elseif k == "model" then 
-            controls[k].ui:set_value (d.val)
-            params:set(k, d.val)
-            legend = braids_engines[params:get(k)]
-            glyph = braids_glyphs[params:get(k)]
-          elseif k == "decim" then
-            params:set(k, d.val/4)
-           controls[k].ui:set_value (d.val/4)
-          elseif k == "bits" then
-            params:set(k, util.round(d.val/21, 0.1))
-            controls[k].ui:set_value (d.val/21)
-          elseif k ~= nil then
-            params:set(k, d.val/100)
-            controls[k].ui:set_value (d.val/100)
+  -- MIDI
+  local mo = midi.connect() -- defaults to port 1 (which is set in SYSTEM > DEVICES)
+  mo.event = function(data) 
+    d = midi.to_msg(data)
+    if params:get('midi_channel') == 0 or d.ch == params:get('midi_channel') then
+      if d.type == "note_on" then
+        --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
+        if metarandom then 
+          meta_random()
+        end
+        current_note = d.note
+        params:set("pitch", d.note)
+        controls.pitch.ui:set_value (d.note)
+        engine.noteOn(d.note, d.vel)
+        redraw()
+      elseif d.type == "note_off" then
+        engine.noteOff(0)
+      end 
+      if d.type == "cc" then
+        for k,v in pairs(controls) do
+          if d.cc == metarandom_cc and d.val > 64 then
+            metarandom = true
+          else
+            metarandom = false
+          end 
+          if controls[k].midi == d.cc then
+            --print ("cc: ".. d.cc .. ", val:" .. d.val)
+            if k == "pitch" then
+              controls[k].ui:set_value (d.val)
+              params:set(k, d.val)
+            elseif k == "model" then 
+              controls[k].ui:set_value (d.val)
+              params:set(k, d.val)
+              legend = braids_engines[params:get(k)]
+              glyph = braids_glyphs[params:get(k)]
+            elseif k == "decim" then
+              params:set(k, d.val/4)
+             controls[k].ui:set_value (d.val/4)
+            elseif k == "bits" then
+              params:set(k, util.round(d.val/21, 0.1))
+              controls[k].ui:set_value (d.val/21)
+            elseif k ~= nil then
+              params:set(k, d.val/100)
+              controls[k].ui:set_value (d.val/100)
+            end
           end
-       end 
-    end  
-    redraw()    
-  end 
+        end
+      end
+    redraw()
   end
 end
-
 
   -- Add params
   MacroB.add_params()

--- a/modal-e.lua
+++ b/modal-e.lua
@@ -92,6 +92,9 @@ function init()
   controls.pos = {ui = nil, midi = nil,}
   controls.space = {ui = nil, midi = nil,}
 
+  params:add{type = "control", id = "midi_channel", name = "MIDI channel",
+    controlspec = controlspec.new(0, 16, "", 1, 0, ""), action = change_midi_channel}
+
   -- create midi pmap for 16n
   print ("check pmap")
   local p = norns.pmap.data.contour
@@ -121,26 +124,28 @@ function init()
   local mo = midi.connect() -- defaults to port 1 (which is set in SYSTEM > DEVICES)
   mo.event = function(data) 
     d = midi.to_msg(data)
-    if d.type == "note_on" then
-      --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
-      current_note = d.note
-      engine.noteOn(d.note)
-      redraw()
-    elseif d.type == "note_off" then
-      engine.noteOff(0)
-    elseif d.type == "cc" then
-      --print ("cc: ".. d.cc .. " : " .. d.val)
-      for k,v in pairs(controls) do
-          if controls[k].midi == d.cc then
-            if k == "pit" then 
-              params:set(k, d.val)
-              controls[k].ui:set_value (d.val)
-            else 
-              params:set(k, d.val/100)
-              controls[k].ui:set_value (d.val/100)
-            end
-          end 
-      end  
+    if params:get('midi_channel') == 0 or d.ch == params:get('midi_channel') then
+      if d.type == "note_on" then
+        --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
+        current_note = d.note
+        engine.noteOn(d.note)
+        redraw()
+      elseif d.type == "note_off" then
+        engine.noteOff(0)
+      elseif d.type == "cc" then
+        --print ("cc: ".. d.cc .. " : " .. d.val)
+        for k,v in pairs(controls) do
+            if controls[k].midi == d.cc then
+              if k == "pit" then 
+                params:set(k, d.val)
+                controls[k].ui:set_value (d.val)
+              else 
+                params:set(k, d.val/100)
+                controls[k].ui:set_value (d.val/100)
+              end
+            end 
+        end  
+      end
       redraw()
     end 
   end
@@ -227,6 +232,10 @@ function enc(n,d)
   redraw()
 end
 
+function change_midi_channel(d)
+  -- shush everything
+  engine.noteOff(0)
+end
 
 function redraw()
   -- screen redraw

--- a/resonate-r.lua
+++ b/resonate-r.lua
@@ -60,6 +60,9 @@ function init()
   controls.bypass = {ui = nil, midi = nil,}
   controls.easteregg = {ui = nil, midi = nil,}
 
+  params:add{type = "control", id = "midi_channel", name = "MIDI channel",
+    controlspec = controlspec.new(0, 16, "", 1, 0, ""), action = change_midi_channel}
+
   -- create midi pmap for 16n
   print ("check pmap")
   local p = norns.pmap.data.pitch
@@ -89,16 +92,18 @@ function init()
   local mo = midi.connect() -- defaults to port 1 (which is set in SYSTEM > DEVICES)
   mo.event = function(data) 
     d = midi.to_msg(data)
-    if d.type == "note_on" then
-      --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
-      current_note = d.note
-      params:set("pitch", d.note)
-      controls.pitch.ui:set_value (d.note)
-      engine.noteOn(d.note)
-      redraw()
-    elseif d.type == "note_off" then
-      engine.noteOff(0)
-    end 
+    if params:get('midi_channel') == 0 or d.ch == params:get('midi_channel') then
+      if d.type == "note_on" then
+        --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
+        current_note = d.note
+        params:set("pitch", d.note)
+        controls.pitch.ui:set_value (d.note)
+        engine.noteOn(d.note)
+        redraw()
+      elseif d.type == "note_off" then
+        engine.noteOff(0)
+      end
+    end
   end
   -- controller on device 2
   local mo2 = midi.connect(2) -- defaults to port 1 (which is set in SYSTEM > DEVICES)
@@ -239,6 +244,10 @@ local function draw_ring(x,y,lev)
   --screen.fill()
 end
 
+function change_midi_channel(d)
+  -- shush everything
+  engine.noteOff(0)
+end
 
 function redraw()
 

--- a/texture-c.lua
+++ b/texture-c.lua
@@ -85,6 +85,9 @@ function init()
   controls.mode = {ui = nil, midi = nil,}
   controls.lofi = {ui = nil, midi = nil,}
 
+  params:add{type = "control", id = "midi_channel", name = "MIDI channel",
+    controlspec = controlspec.new(0, 16, "", 1, 0, ""), action = change_midi_channel}
+
   -- create midi pmap for 16n
   print ("check pmap")
   local p = norns.pmap.data.pitch
@@ -112,32 +115,32 @@ function init()
   local mo = midi.connect() -- defaults to port 1 (which is set in SYSTEM > DEVICES)
   mo.event = function(data) 
     d = midi.to_msg(data)
-    if d.type == "note_on" then
-      --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
-      current_note = d.note
-      params:set("pitch",d.note)
-      params:set("trig",1)
-      redraw()
-    elseif d.type == "note_off" then
-      params:set("trig",0)
-    elseif d.type == "cc" then
-      --print ("cc: ".. d.cc .. " : " .. d.val)
-      for k,v in pairs(controls) do
-          if controls[k].midi == d.cc then
-            if k == "pitch" then 
-              params:set(k, d.val)
-              controls[k].ui:set_value (d.val)
-            else 
-              params:set(k, d.val/100)
-              controls[k].ui:set_value (d.val/100)
-            end
-          end 
-      end  
+    if params:get('midi_channel') == 0 or d.ch == params:get('midi_channel') then
+      if d.type == "note_on" then
+        --print ("note-on: ".. d.note .. ", velocity:" .. d.vel)
+        current_note = d.note
+        params:set("pitch",d.note)
+        params:set("trig",1)
+        redraw()
+      elseif d.type == "note_off" then
+        params:set("trig",0)
+      elseif d.type == "cc" then
+        --print ("cc: ".. d.cc .. " : " .. d.val)
+        for k,v in pairs(controls) do
+            if controls[k].midi == d.cc then
+              if k == "pitch" then 
+                params:set(k, d.val)
+                controls[k].ui:set_value (d.val)
+              else 
+                params:set(k, d.val/100)
+                controls[k].ui:set_value (d.val/100)
+              end
+            end 
+        end  
+      end
       redraw()
     end 
   end
-
-
 
   -- UI
   local row1 = 12
@@ -230,6 +233,9 @@ local function draw_cloud(x,y,lev)
   screen.stroke()
 end
 
+function change_midi_channel(d)
+  -- shush everything. But how?
+end
 
 function redraw()
   -- screen redraw


### PR DESCRIPTION
Hi, I added a settings for each of the scripts to listen to a specific MIDI channel, or if set to 0 (default), respond to all of the MIDI channels. I decided to include this setting in the script settings rather than as part of the engines in `lib/`, because I would think that is the scripts rather than engine's responsibility to do the playing. Review and feedback most welcome of course!

Thanks for all the work on these engines!